### PR TITLE
fix: naming-convention

### DIFF
--- a/rules/typescript.mjs
+++ b/rules/typescript.mjs
@@ -47,15 +47,11 @@ export const typescript = [
         {
           selector: 'default',
           format: ['camelCase'],
+          leadingUnderscore: 'allow',
         },
         {
           selector: 'variable',
-          format: ['camelCase', 'UPPER_CASE'],
-        },
-        {
-          selector: 'parameter',
-          format: ['camelCase'],
-          leadingUnderscore: 'allow',
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
         },
         {
           selector: 'function',


### PR DESCRIPTION
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced naming conventions for TypeScript identifiers, allowing leading underscores.
	- Expanded variable naming formats to include `PascalCase`, alongside existing formats.

- **Changes**
	- Removed the `parameter` selector from the configuration, which may affect parameter formatting in TypeScript code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->