### PR TITLE
fix: configure @typescript-eslint/consistent-type-imports

### DIFF
--- a/rules/typescript.mjs
+++ b/rules/typescript.mjs
@@ -73,6 +73,10 @@ export const typescript = [
       '@typescript-eslint/array-type': ['error', { default: 'array-simple', readonly: 'generic' }],
       '@typescript-eslint/restrict-template-expressions': ['error', { allowNullish: true }],
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
     },
   },
   {


### PR DESCRIPTION
Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linting rule for TypeScript to enforce consistent handling of type imports.
	- The rule encourages the use of `type-imports` and supports automatic style fixing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->