### PR TITLE
chore: configure switch-exhaustiveness-check

### DIFF
--- a/rules/typescript.mjs
+++ b/rules/typescript.mjs
@@ -63,7 +63,7 @@ export const typescript = [
         },
       ],
 
-      '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': ['error', { considerDefaultExhaustiveForUnions: true }],
       'default-case': 'off',
 
       '@typescript-eslint/no-non-null-assertion': 'warn',


### PR DESCRIPTION
After an eslint update, via's checks started failing with this rule mostly. Adding the option "considerDefaultExhaustiveForUnions" seems relevant for switch exhaustiveness checks.

See: [VIA's pull request 1024](https://github.com/valian-ca/vialepole/pull/1024)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error checking for TypeScript with a refined `@typescript-eslint/switch-exhaustiveness-check` rule, now considering default cases as exhaustive for union types.

- **Bug Fixes**
	- Improved functionality of existing linting rules for TypeScript files without introducing new rules or removing any.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->