### PR TITLE
fix(rules): enable file extensions when importing non JS/TS files

### DIFF
--- a/rules/base.mjs
+++ b/rules/base.mjs
@@ -50,6 +50,7 @@ export const base = [
 
       'import-x/extensions': [
         'error',
+        'always',
         {
           js: 'never',
           jsx: 'never',


### PR DESCRIPTION
This prevents errors when importing json files.

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised internal configuration to enforce consistent file extension usage in import statements, aligning with best practices and reducing potential discrepancies for code behavior. This change is purely internal, not affecting visible application functionality, but contributes to improved code quality and long-term maintainability through a standardized approach to file import practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->